### PR TITLE
Image filenames with spaces need double quotes around URL. :)

### DIFF
--- a/glisse.js
+++ b/glisse.js
@@ -208,7 +208,7 @@
             spinner(true);
             var url = pic,
                 img = $('<img/>',{src: url}).appendTo(plugin.els['content']);
-            plugin.els['content'].css({ backgroundImage: 'url('+url+')'});
+            plugin.els['content'].css({ backgroundImage: 'url("'+url+'")'});
             
             img.load(function() {
                 img.remove();
@@ -263,7 +263,7 @@
 
                     var url = pictureUrl,
                         img = $('<img/>',{src: url}).appendTo(plugin.els['content']);
-                    plugin.els['content'].css({ backgroundImage: 'url('+url+')'});
+                    plugin.els['content'].css({ backgroundImage: 'url("'+url+'")'});
                     
                     img.load(function() {
                         img.remove();


### PR DESCRIPTION
Surrounded url for backgroundImage in double quotes to support filenames with spaces.
