### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ Valid options for glisse.js are:
     * flipY
 
                        
-##Compatibility
+## Compatibility
 
 * Firefox 4+
 * Opera 11.6+


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
